### PR TITLE
modified to be packable as a net6.0 tool

### DIFF
--- a/source/AliaSQL.Console/AliaSQL.Console.csproj
+++ b/source/AliaSQL.Console/AliaSQL.Console.csproj
@@ -1,30 +1,21 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Version>2.0.0.1111</Version>
+    <TargetFrameworks>net6.0;net461</TargetFrameworks>
+    <Version>2.0.0.1112</Version>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />
+    <PackageId>AliaSQL</PackageId>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AliaSQL.Core\AliaSQL.Core.csproj" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>NETSTANDARD;NETSTANDARD2_0</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net461'">
     <DefineConstants>net461;NETFULL</DefineConstants>
   </PropertyGroup>
-  <!--<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\AliasSQL.Core.xml</DocumentationFile>
-  </PropertyGroup>-->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0'">
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>aliasql</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
I rewrote the console app's csproj so you can build it with `dotnet pack` and it spits out a nuget package with a netframework 4.6.1 version, but also installable with `dotnet tool install aliasql`. I also cleaned up some stuff I didn't think looked like it was necessary/needed, but ymmv. Let me know if you have any questions or hate it or whatever.